### PR TITLE
Ability to symbolicate RTF files (as generated by the crash reporter)

### DIFF
--- a/Simba/Symbolicator/SBFileAcceptingImageView.m
+++ b/Simba/Symbolicator/SBFileAcceptingImageView.m
@@ -72,7 +72,7 @@
     if (nil == carriedData)
     {
         //the operation failed for some reason
-        NSRunAlertPanel(@"Paste Error", @"Sorry, but the past operation failed", 
+        NSRunAlertPanel(@"Paste Error", @"Sorry, but the paste operation failed",
 						nil, nil, nil);
         return NO;
     }

--- a/Simba/Symbolicator/Simba-Info.plist
+++ b/Simba/Symbolicator/Simba-Info.plist
@@ -40,7 +40,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Simba/Symbolicator/en.lproj/Credits.rtf
+++ b/Simba/Symbolicator/en.lproj/Credits.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1138\cocoasubrtf230
+{\rtf1\ansi\ansicpg1252\cocoartf1187\cocoasubrtf340
 {\fonttbl\f0\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;}
 \paperw11900\paperh16840\vieww9600\viewh8400\viewkind0
@@ -6,12 +6,13 @@
 
 \f0\b\fs24 \cf0 Engineering:
 \b0 \
-	Zac Cohan & Nik Youdale\
+Zac Cohan & Nik Youdale\
+RTF conversion: Pete Goodliffe\
 \
 
 \b How to Use:\
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural
-\cf0 	
-\b0 Xcode produces a .dSYM file when you archive your application, which can be used to symbolicate crash reports. \
+
+\b0 \cf0 Xcode produces a .dSYM file when you archive your application, which can be used to symbolicate crash reports. \
 \
-	Your app's .dSYM file can be found in the archive of your app produced by Xcode, and must come from the same build that has produced the crash report. }
+Your app's .dSYM file can be found in the archive of your app produced by Xcode, and must come from the same build that has produced the crash report. }


### PR DESCRIPTION
These reports are generated by the end-used crash reporter facility, so an automatic
conversion step makes symbolicating far, far less tedious.
